### PR TITLE
Update for CVEs. Deduplicate the same jars with different versions.

### DIFF
--- a/BROADLEAF.MD
+++ b/BROADLEAF.MD
@@ -4,12 +4,12 @@
 - `./gradlew test` (Full test suite takes 4 hours!!)
 - At the time of this writing, `SocketServerTest` consistently fails - even without any changes. As a result, ignoring this particular test result.
 - `./gradlew clean releaseTarGz`
-- For local testing: `FULLY_QUALIFIED_MAIN_IMAGE_TAG=repository.broadleafcommerce.com:5001/broadleaf/kafka:3.9.1-alpine-3.22-jre-21.0.8_9-r1 BUILD_AND_LOAD_LOCAL_PLATFORM_ONLY=true docker buildx bake -f docker-bake.hcl`
+- For local testing: `FULLY_QUALIFIED_MAIN_IMAGE_TAG=repository.broadleafcommerce.com:5001/broadleaf/kafka:3.9.1-alpine-3.23-jre-21.0.9_10-kraft1 BUILD_AND_LOAD_LOCAL_PLATFORM_ONLY=true docker buildx bake -f docker-bake.hcl`
 - For release: 
-  - `FULLY_QUALIFIED_MAIN_IMAGE_TAG=repository.broadleafcommerce.com:5001/broadleaf/kafka:3.9.1-alpine-3.22-jre-21.0.8_9-r1 LIMIT_PLATFORM="linux/arm64" docker buildx bake --builder blc-devops-multiplatform-builder -f docker-bake.hcl`
-  - `FULLY_QUALIFIED_MAIN_IMAGE_TAG=repository.broadleafcommerce.com:5001/broadleaf/kafka:3.9.1-alpine-3.22-jre-21.0.8_9-r1 LIMIT_PLATFORM="linux/amd64" docker buildx bake --builder blc-devops-multiplatform-builder -f docker-bake.hcl`
-  - `FULLY_QUALIFIED_MAIN_IMAGE_TAG=repository.broadleafcommerce.com:5001/broadleaf/kafka:3.9.1-alpine-3.22-jre-21.0.8_9-r1 docker buildx bake --builder blc-devops-multiplatform-builder -f docker-bake.hcl --push`
-  - (Increment the `r1` to a higher value if only changing java or os deps without changing app, jre, or os versions)
+  - `FULLY_QUALIFIED_MAIN_IMAGE_TAG=repository.broadleafcommerce.com:5001/broadleaf/kafka:3.9.1-alpine-3.23-jre-21.0.9_10-kraft1 LIMIT_PLATFORM="linux/arm64" docker buildx bake --builder blc-devops-multiplatform-builder -f docker-bake.hcl`
+  - `FULLY_QUALIFIED_MAIN_IMAGE_TAG=repository.broadleafcommerce.com:5001/broadleaf/kafka:3.9.1-alpine-3.23-jre-21.0.9_10-kraft1 LIMIT_PLATFORM="linux/amd64" docker buildx bake --builder blc-devops-multiplatform-builder -f docker-bake.hcl`
+  - `FULLY_QUALIFIED_MAIN_IMAGE_TAG=repository.broadleafcommerce.com:5001/broadleaf/kafka:3.9.1-alpine-3.23-jre-21.0.9_10-kraft1 docker buildx bake --builder blc-devops-multiplatform-builder -f docker-bake.hcl --push`
+  - (Increment the `kraft1` to a higher value if only changing java or os deps without changing app, jre, or os versions)
 ## Update Notes
 - The `Dockerfile` at the root of this project was adapted from the `jvm` instruction set located at `docker/jvm/Dockerfile`, and was updated to pull from a local kafka build (i.e. `./core/build/distributions/`) instead of the Apache Distribution Repo and references existing scripts and resources in the `./docker` directory.
 - A `docker-bake.hcl` file was added in support of a multi-platform builds

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 
 # Stage 1: Build Java Shared Archive (JSA)
 # Adapted from the official Apache Dockerfile
-FROM eclipse-temurin:21.0.8_9-jre-alpine-3.22 AS build-jsa
+FROM eclipse-temurin:21.0.9_10-jre-alpine-3.23 AS build-jsa
 
 USER root
 
@@ -91,7 +91,7 @@ RUN ls -la /tmp/strimzi-extracted/scripts /tmp/strimzi-extracted/kafka-exporter 
 
 # Stage 3: Main Kafka image build
 # Adapted from the official Apache Dockerfile
-FROM eclipse-temurin:21.0.8_9-jre-alpine-3.22
+FROM eclipse-temurin:21.0.9_10-jre-alpine-3.23
 
 # exposed ports
 EXPOSE 9092
@@ -138,6 +138,7 @@ RUN set -eux ; \
 COPY --from=build-jsa kafka.jsa /opt/kafka/kafka.jsa
 COPY --from=build-jsa storage.jsa /opt/kafka/storage.jsa
 COPY --chown=appuser:0 docker/resources/common-scripts /etc/kafka/docker
+RUN chmod +x /etc/kafka/docker/copy-jars.sh
 COPY --chown=appuser:0 docker/jvm/launch /etc/kafka/docker/launch
 
 VOLUME ["/etc/kafka/secrets", "/var/lib/kafka/data", "/mnt/shared/config"]
@@ -183,14 +184,19 @@ RUN rm -rf ${KAFKA_HOME}/strimzi-scripts
 COPY --from=strimzi-source-extractor --chown=appuser:root /tmp/strimzi-extracted/prometheus-jmx-exporter ${JMX_EXPORTER_HOME}
 
 # Copy Strimzi Agents and other Kafka libraries
-COPY --from=strimzi-source-extractor --chown=appuser:root /tmp/strimzi-extracted/kafka-libs/ ${KAFKA_HOME}/strimzi-kafka-libs/
-# Copy from strimzi temp directory into main kafka lib, skip files if they already exist
-RUN cp -n ${KAFKA_HOME}/strimzi-kafka-libs/* ${KAFKA_HOME}/libs
-RUN rm -rf ${KAFKA_HOME}/strimzi-kafka-libs
+# Use a bind mount to access files from the previous stage without copying them permanently into a layer first
+RUN --mount=type=bind,from=strimzi-source-extractor,source=/tmp/strimzi-extracted/kafka-libs,target=/tmp/strimzi-kafka-libs-source \
+    /etc/kafka/docker/copy-jars.sh /tmp/strimzi-kafka-libs-source ${KAFKA_HOME}/libs && \
+    chown -R appuser:root ${KAFKA_HOME}/libs
 
 # Copy Cruise Control libraries
-COPY --from=strimzi-source-extractor --chown=appuser:root /tmp/strimzi-extracted/cruise-control/ ${CRUISE_CONTROL_HOME}
-RUN chmod -R +x ${CRUISE_CONTROL_HOME} || true
+# Use a bind mount to access files from the previous stage
+# We copy libs using the deduplication script, and other files directly
+RUN --mount=type=bind,from=strimzi-source-extractor,source=/tmp/strimzi-extracted/cruise-control,target=/tmp/cruise-control-source \
+    bash -c '/etc/kafka/docker/copy-jars.sh /tmp/cruise-control-source/libs ${CRUISE_CONTROL_HOME}/libs ${KAFKA_HOME}/libs && \
+    find /tmp/cruise-control-source -maxdepth 1 -mindepth 1 -not -name libs -exec cp -r {} ${CRUISE_CONTROL_HOME}/ \;' && \
+    chown -R appuser:root ${CRUISE_CONTROL_HOME} && \
+    chmod -R +x ${CRUISE_CONTROL_HOME}
 
 # Important to set this to the kafka home as strimzi scripts have relative path references
 WORKDIR $KAFKA_HOME

--- a/build.gradle
+++ b/build.gradle
@@ -161,6 +161,8 @@ allprojects {
           // ZooKeeper (potentially older and containing CVEs)
           libs.nettyHandler,
           libs.nettyTransportNativeEpoll,
+          libs.nettyCodecHttp,
+          libs.nettyCodecHttp2,
           // be explicit about the reload4j version instead of relying on the transitive versions
           libs.reload4j,
           libs.commonsLang3
@@ -971,6 +973,16 @@ project(':core') {
     }
     // ZooKeeperMain depends on commons-cli but declares the dependency as `provided`
     implementation libs.commonsCli
+
+    // Strimzi and cruise control deps
+    // Overridden for CVEs
+    implementation libs.nettyCodecHttp
+    implementation libs.nettyCodecHttp2
+    implementation libs.nimbusJoseJwt
+    implementation libs.log4J
+    implementation libs.vertxCore
+    implementation libs.vertxWeb
+    // End Strimzi and cruise control deps
 
     compileOnly libs.reload4j
 

--- a/docker/resources/common-scripts/copy-jars.sh
+++ b/docker/resources/common-scripts/copy-jars.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# Copies files from SOURCE to TARGET.
+# 1. If JAR exists in TARGET (ignoring version), skip.
+# 2. If JAR exists in ADDITIONAL_CHECK_DIR (ignoring version), copy the version from ADDITIONAL_CHECK_DIR to TARGET.
+# 3. Otherwise, copy from SOURCE to TARGET.
+#
+# Usage: copy-jars.sh <SOURCE_DIR> <TARGET_DIR> [ADDITIONAL_CHECK_DIR]
+
+set -e
+
+SOURCE_DIR="$1"
+TARGET_DIR="$2"
+ADDITIONAL_CHECK_DIR="$3"
+
+if [ -z "$SOURCE_DIR" ] || [ -z "$TARGET_DIR" ]; then
+    echo "Usage: $0 <SOURCE_DIR> <TARGET_DIR> [ADDITIONAL_CHECK_DIR]"
+    exit 1
+fi
+
+# Ensure target exists
+mkdir -p "$TARGET_DIR"
+
+echo "Copying files from $SOURCE_DIR to $TARGET_DIR with version deduplication..."
+if [ -n "$ADDITIONAL_CHECK_DIR" ]; then
+    echo "Also checking for duplicates in $ADDITIONAL_CHECK_DIR"
+fi
+
+# Helper to extract base name (artifact ID)
+get_base_name() {
+    local filename=$1
+    # Remove version suffix starting with a hyphen followed by a digit
+    echo "$filename" | sed -E 's/-[0-9].*\.jar$//'
+}
+
+# Process JAR files
+# We use a loop over the glob to handle filenames with spaces correctly
+shopt -s nullglob
+for src_jar in "$SOURCE_DIR"/*.jar; do
+    filename=$(basename "$src_jar")
+    base_name=$(get_base_name "$filename")
+
+    duplicate_in_target=false
+
+    # Check against all jars in target
+    for target_jar in "$TARGET_DIR"/*.jar; do
+        t_filename=$(basename "$target_jar")
+        t_base_name=$(get_base_name "$t_filename")
+
+        if [ "$base_name" == "$t_base_name" ]; then
+            echo "Skipping $filename (duplicate of $t_filename in target)"
+            duplicate_in_target=true
+            break
+        fi
+    done
+
+    if [ "$duplicate_in_target" = true ]; then
+        continue
+    fi
+
+    # Check additional directory if provided
+    copied_from_additional=false
+    if [ -n "$ADDITIONAL_CHECK_DIR" ] && [ -d "$ADDITIONAL_CHECK_DIR" ]; then
+        for check_jar in "$ADDITIONAL_CHECK_DIR"/*.jar; do
+            c_filename=$(basename "$check_jar")
+            c_base_name=$(get_base_name "$c_filename")
+
+            if [ "$base_name" == "$c_base_name" ]; then
+                echo "Found duplicate in additional dir: $c_filename. Copying that version to target."
+                cp "$check_jar" "$TARGET_DIR/"
+                copied_from_additional=true
+                break
+            fi
+        done
+    fi
+
+    if [ "$copied_from_additional" = false ]; then
+        echo "Copying $filename"
+        cp "$src_jar" "$TARGET_DIR/"
+    fi
+done
+
+# Process non-JAR files and directories
+# We copy them if they don't exist in target (exact name match)
+for src_file in "$SOURCE_DIR"/*; do
+    filename=$(basename "$src_file")
+
+    # Skip if it's a jar (already handled)
+    if [[ "$filename" == *.jar ]]; then
+        continue
+    fi
+
+    if [ ! -e "$TARGET_DIR/$filename" ]; then
+        echo "Copying $filename"
+        cp -r "$src_file" "$TARGET_DIR/"
+    else
+        echo "Skipping $filename (exists)"
+    fi
+done

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -112,7 +112,7 @@ versions += [
   jaxrs: "2.1.1",
   jfreechart: "1.0.0",
   jopt: "5.0.4",
-  jose4j: "0.9.4",
+  jose4j: "0.9.6",
   junit: "5.10.2",
   jqwik: "1.8.3",
   kafka_0100: "0.10.0.1",
@@ -143,7 +143,7 @@ versions += [
   lz4: "1.8.0",
   mavenArtifact: "3.9.6",
   metrics: "2.2.0",
-  netty: "4.1.125.Final",
+  netty: "4.1.130.Final",
   opentelemetryProto: "1.0.0-alpha",
   protobuf: "3.25.5", // a dependency of opentelemetryProto
   pcollections: "4.0.1",
@@ -165,7 +165,10 @@ versions += [
   // When updating the zstd version, please do as well in docker/native/native-image-configs/resource-config.json
   // Also make sure the compression levels in org.apache.kafka.common.record.CompressionType are still valid
   zstd: "1.5.6-4",
-  junitPlatform: "1.10.2"
+  junitPlatform: "1.10.2",
+  nimbusJoseJwt: "9.37.4",
+  log4J: "2.25.3",
+  vertx: "4.5.24"
 ]
 
 libs += [
@@ -247,6 +250,8 @@ libs += [
   mockitoJunitJupiter: "org.mockito:mockito-junit-jupiter:$mockitoVersion",
   nettyHandler: "io.netty:netty-handler:$versions.netty",
   nettyTransportNativeEpoll: "io.netty:netty-transport-native-epoll:$versions.netty",
+  nettyCodecHttp: "io.netty:netty-codec-http:$versions.netty",
+  nettyCodecHttp2: "io.netty:netty-codec-http2:$versions.netty",
   pcollections: "org.pcollections:pcollections:$versions.pcollections",
   opentelemetryProto: "io.opentelemetry.proto:opentelemetry-proto:$versions.opentelemetryProto",
   protobuf: "com.google.protobuf:protobuf-java:$versions.protobuf",
@@ -267,5 +272,9 @@ libs += [
   jfreechart: "jfreechart:jfreechart:$versions.jfreechart",
   mavenArtifact: "org.apache.maven:maven-artifact:$versions.mavenArtifact",
   zstd: "com.github.luben:zstd-jni:$versions.zstd",
-  httpclient: "org.apache.httpcomponents:httpclient:$versions.httpclient"
+  httpclient: "org.apache.httpcomponents:httpclient:$versions.httpclient",
+  nimbusJoseJwt: "com.nimbusds:nimbus-jose-jwt:$versions.nimbusJoseJwt",
+  log4J: "org.apache.logging.log4j:log4j-core:$versions.log4J",
+  vertxCore: "io.vertx:vertx-core:$versions.vertx",
+  vertxWeb: "io.vertx:vertx-web:$versions.vertx"
 ]


### PR DESCRIPTION
- Update several deps for CVEs
- More importantly, remove duplicates found by the scanner. It appears that the Strimzi extraction phase has the possibility for different library versions of the same lib. This was resulting in the scanner finding multiple versions of the same dep, which is not desired. This PR address by determining if the jar to be copied is the same (regardless of version) and ignoring if so. This means that we need to keep up the kafka core with all the meaningful libs and versions.
